### PR TITLE
更新单元测试mock框架

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "require": {
         "smarty/smarty": "3.1.18",
         "phpunit/phpunit": "4.8",
-        "lancerhe/phpunit-mock": "dev-master",
+        "windrainw/phpunit-mock": "dev-master",
         "php-amqplib/php-amqplib": "2.6.2"
     },
     "autoload": {
@@ -27,7 +27,7 @@
         },
         {
             "type": "vcs",
-            "url": "git@github.com:lancerhe/phpunit-mock.git"
+            "url": "git@github.com:windrainw/phpunit-mock.git"
         },
         {
             "type": "composer",


### PR DESCRIPTION
更新单元测试mock框架，在mock由魔术方法__call实现的方法时，runkit_method_rename前需检查方法是否存在，且需要在--process-isolation下运行
